### PR TITLE
feat: add take method to remove item by key and return result

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -330,8 +330,8 @@ mod tests {
         let db = create_test_db().unwrap();
         let tree1 = db.get_tree::<TestSchema1>().unwrap();
 
-        let result: TransactionResult<Option<TestValue>, crate::error::Error> =
-            (&tree1,).transaction(|(tx_tree1,)| {
+        let result: TransactionResult<Option<TestValue>, crate::error::Error> = (&tree1,)
+            .transaction(|(tx_tree1,)| {
                 let taken = tx_tree1.take(&999)?;
                 assert!(taken.is_none());
                 Ok(taken)


### PR DESCRIPTION
## Description

Existing remove method does not return removed value. 
Returned value also needs to be decoded, which is not always required. 
Thus, adding new method `take` that is equivalent to remove and returns the decoded existing value (if it exists).

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
