### PR TITLE
Add custom abort error variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "typed-sled"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "borsh",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "typed-sled"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Bibek Pandey <bibek@alpenlabs.io>"]
 description = "A type-safe wrapper around the sled embedded database"
@@ -17,7 +17,7 @@ rust.unreachable_pub = "warn"
 rust.unused_crate_dependencies = "deny"
 rust.unused_must_use = "deny"
 rust.unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(coverage, coverage_nightly)',
+    'cfg(coverage, coverage_nightly)',
 ] }
 rust.missing_docs = "warn"
 rustdoc.all = "warn"


### PR DESCRIPTION
## Description

This PR adds a custom Abort Error variant in `sled::error::Error` which was missing in the library.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency update
- [ ] Security fix

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
